### PR TITLE
Move hex and format to project plugins

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -5,7 +5,7 @@
 
 {edoc_opts, [{preprocess, true}]}.
 
-{plugins, [rebar3_hex, rebar3_format]}.
+{project_plugins, [rebar3_hex, rebar3_format]}.
 
 {shell,
  % {config, "config/sys.config"},


### PR DESCRIPTION
`project_plugins` are for plugins that are used when developing on the project itself and not required for building the application, so they are ignored when used as a dependency.

Since there is no reason a user should have to fetch and build `rebar3_hex` or `rebar3_format` when using `logflare_erl` as a dependency it is best to have both of those in `project_plugins`.

Another suggestion is to remove `rebar3_hex` and simply use it through global plugins set in `~/.config/rebar3/rebar.config`.